### PR TITLE
docs: normalize explore subagent naming

### DIFF
--- a/gsd-opencode/command/gsd/help.md
+++ b/gsd-opencode/command/gsd/help.md
@@ -56,7 +56,7 @@ Usage: `/gsd:create-roadmap`
 **`/gsd:map-codebase`**
 Map an existing codebase for brownfield projects.
 
-- Analyzes codebase with parallel Explore agents
+- Analyzes codebase with parallel explore agents
 - Creates `.planning/codebase/` with 7 focused documents
 - Covers stack, architecture, structure, conventions, testing, integrations, concerns
 - Use before `/gsd:new-project` on existing codebases

--- a/gsd-opencode/command/gsd/map-codebase.md
+++ b/gsd-opencode/command/gsd/map-codebase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:map-codebase
-description: Analyze codebase with parallel Explore agents to produce .planning/codebase/ documents
+description: Analyze codebase with parallel explore agents to produce .planning/codebase/ documents
 argument-hint: "[optional: specific area to map, e.g., 'api' or 'auth']"
 allowed-tools:
   - Read
@@ -12,9 +12,9 @@ allowed-tools:
 ---
 
 <objective>
-Analyze existing codebase using parallel Explore agents to produce structured codebase documents.
+Analyze existing codebase using parallel explore agents to produce structured codebase documents.
 
-This command spawns multiple Explore agents to analyze different aspects of the codebase in parallel, each with fresh context.
+This command spawns multiple explore agents to analyze different aspects of the codebase in parallel, each with fresh context.
 
 Output: .planning/codebase/ folder with 7 structured documents about the codebase state.
 </objective>
@@ -58,7 +58,7 @@ Check for .planning/STATE.md - loads context if project already initialized
 <process>
 1. Check if .planning/codebase/ already exists (offer to refresh or skip)
 2. Create .planning/codebase/ directory structure
-3. Spawn 4 parallel Explore agents to analyze codebase:
+3. Spawn 4 parallel explore agents to analyze codebase:
    - Agent 1: Stack + Integrations (technology focus)
    - Agent 2: Architecture + Structure (organization focus)
    - Agent 3: Conventions + Testing (quality focus)

--- a/gsd-opencode/get-shit-done/templates/codebase/concerns.md
+++ b/gsd-opencode/get-shit-done/templates/codebase/concerns.md
@@ -306,5 +306,5 @@ Template for `.planning/codebase/CONCERNS.md` - captures known issues and areas 
 - Planning refactoring work
 
 **How this gets populated:**
-Explore agents detect these during codebase mapping. Manual additions welcome for human-discovered issues. This is living documentation, not a complaint list.
+explore agents detect these during codebase mapping. Manual additions welcome for human-discovered issues. This is living documentation, not a complaint list.
 </guidelines>

--- a/gsd-opencode/get-shit-done/workflows/map-codebase.md
+++ b/gsd-opencode/get-shit-done/workflows/map-codebase.md
@@ -1,5 +1,5 @@
 <purpose>
-Orchestrate parallel Explore agents to analyze codebase and produce structured documents in .planning/codebase/
+Orchestrate parallel explore agents to analyze codebase and produce structured documents in .planning/codebase/
 
 Each agent has fresh context and focuses on specific aspects. Output is concise and actionable for planning.
 </purpose>
@@ -69,15 +69,15 @@ Continue to spawn_agents.
 </step>
 
 <step name="spawn_agents">
-Spawn 4 parallel Explore agents to analyze codebase.
+Spawn 4 parallel explore agents to analyze codebase.
 
-Use Task tool with `subagent_type="Explore"` and `run_in_background=true` for parallel execution.
+Use Task tool with `subagent_type="explore"` and `run_in_background=true` for parallel execution.
 
 **Agent 1: Stack + Integrations (Technology Focus)**
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Analyze codebase technology stack and external integrations"
 ```
@@ -121,7 +121,7 @@ If something is not found, note "Not detected" for that category.
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Analyze codebase architecture patterns and directory structure"
 ```
@@ -164,7 +164,7 @@ If something is not clear, provide best-guess interpretation based on code struc
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Analyze coding conventions and test patterns"
 ```
@@ -208,7 +208,7 @@ Look at actual code files to infer conventions if config files are missing.
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Identify technical debt and areas of concern"
 ```
@@ -424,7 +424,7 @@ End workflow.
 
 <success_criteria>
 - .planning/codebase/ directory created
-- 4 parallel Explore agents spawned with run_in_background=true
+- 4 parallel explore agents spawned with run_in_background=true
 - Agent prompts are specific and actionable
 - TaskOutput used to collect all agent results
 - All 7 codebase documents written using template filling

--- a/src/get-shit-done/commands/gsd/help.md
+++ b/src/get-shit-done/commands/gsd/help.md
@@ -56,7 +56,7 @@ Usage: `/gsd:create-roadmap`
 **`/gsd:map-codebase`**
 Map an existing codebase for brownfield projects.
 
-- Analyzes codebase with parallel Explore agents
+- Analyzes codebase with parallel explore agents
 - Creates `.planning/codebase/` with 7 focused documents
 - Covers stack, architecture, structure, conventions, testing, integrations, concerns
 - Use before `/gsd:new-project` on existing codebases

--- a/src/get-shit-done/commands/gsd/map-codebase.md
+++ b/src/get-shit-done/commands/gsd/map-codebase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:map-codebase
-description: Analyze codebase with parallel Explore agents to produce .planning/codebase/ documents
+description: Analyze codebase with parallel explore agents to produce .planning/codebase/ documents
 argument-hint: "[optional: specific area to map, e.g., 'api' or 'auth']"
 allowed-tools:
   - Read
@@ -12,9 +12,9 @@ allowed-tools:
 ---
 
 <objective>
-Analyze existing codebase using parallel Explore agents to produce structured codebase documents.
+Analyze existing codebase using parallel explore agents to produce structured codebase documents.
 
-This command spawns multiple Explore agents to analyze different aspects of the codebase in parallel, each with fresh context.
+This command spawns multiple explore agents to analyze different aspects of the codebase in parallel, each with fresh context.
 
 Output: .planning/codebase/ folder with 7 structured documents about the codebase state.
 </objective>
@@ -58,7 +58,7 @@ Check for .planning/STATE.md - loads context if project already initialized
 <process>
 1. Check if .planning/codebase/ already exists (offer to refresh or skip)
 2. Create .planning/codebase/ directory structure
-3. Spawn 4 parallel Explore agents to analyze codebase:
+3. Spawn 4 parallel explore agents to analyze codebase:
    - Agent 1: Stack + Integrations (technology focus)
    - Agent 2: Architecture + Structure (organization focus)
    - Agent 3: Conventions + Testing (quality focus)

--- a/src/get-shit-done/get-shit-done/templates/codebase/concerns.md
+++ b/src/get-shit-done/get-shit-done/templates/codebase/concerns.md
@@ -306,5 +306,5 @@ Template for `.planning/codebase/CONCERNS.md` - captures known issues and areas 
 - Planning refactoring work
 
 **How this gets populated:**
-Explore agents detect these during codebase mapping. Manual additions welcome for human-discovered issues. This is living documentation, not a complaint list.
+explore agents detect these during codebase mapping. Manual additions welcome for human-discovered issues. This is living documentation, not a complaint list.
 </guidelines>

--- a/src/get-shit-done/get-shit-done/workflows/map-codebase.md
+++ b/src/get-shit-done/get-shit-done/workflows/map-codebase.md
@@ -1,5 +1,5 @@
 <purpose>
-Orchestrate parallel Explore agents to analyze codebase and produce structured documents in .planning/codebase/
+Orchestrate parallel explore agents to analyze codebase and produce structured documents in .planning/codebase/
 
 Each agent has fresh context and focuses on specific aspects. Output is concise and actionable for planning.
 </purpose>
@@ -69,15 +69,15 @@ Continue to spawn_agents.
 </step>
 
 <step name="spawn_agents">
-Spawn 4 parallel Explore agents to analyze codebase.
+Spawn 4 parallel explore agents to analyze codebase.
 
-Use Task tool with `subagent_type="Explore"` and `run_in_background=true` for parallel execution.
+Use Task tool with `subagent_type="explore"` and `run_in_background=true` for parallel execution.
 
 **Agent 1: Stack + Integrations (Technology Focus)**
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Analyze codebase technology stack and external integrations"
 ```
@@ -121,7 +121,7 @@ If something is not found, note "Not detected" for that category.
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Analyze codebase architecture patterns and directory structure"
 ```
@@ -164,7 +164,7 @@ If something is not clear, provide best-guess interpretation based on code struc
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Analyze coding conventions and test patterns"
 ```
@@ -208,7 +208,7 @@ Look at actual code files to infer conventions if config files are missing.
 
 Task tool parameters:
 ```
-subagent_type: "Explore"
+subagent_type: "explore"
 run_in_background: true
 task_description: "Identify technical debt and areas of concern"
 ```
@@ -424,7 +424,7 @@ End workflow.
 
 <success_criteria>
 - .planning/codebase/ directory created
-- 4 parallel Explore agents spawned with run_in_background=true
+- 4 parallel explore agents spawned with run_in_background=true
 - Agent prompts are specific and actionable
 - TaskOutput used to collect all agent results
 - All 7 codebase documents written using template filling


### PR DESCRIPTION
- Summary
  - Standardize subagent_type to lowercase explore in map-codebase docs.
  - Align “explore agents” wording across source and packaged docs.
  - Fixes https://github.com/rokicool/gsd-opencode/issues/4