### PR TITLE
fix(ci): add GH_TOKEN for GitHub CLI authentication in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,9 @@ jobs:
       contents: write
       id-token: write
 
+    env:
+      GH_TOKEN: ${{ github.token }}
+
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Summary
- Add GH_TOKEN environment variable to create_release job in GitHub Actions
- Fix GitHub CLI authentication error when creating releases in CI/CD pipeline
- Ensure gh release create command works properly with ${{ github.token }}
Additional important details
- Files changed: 1 (.github/workflows/release.yml)
- Lines added: 3 insertions
- Type: fix - resolves authentication failure in automated release process
- Impact: Fixes GitHub release creation workflow that was failing with "GH_TOKEN environment variable not set" error