### PR TITLE
fix(ci): remove duplicate update_version job definition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,46 +54,6 @@ jobs:
           UPDATED_NAME=$(node -p "require('./package.json').name")
           echo "✓ Package name updated to: $UPDATED_NAME"
 
-  update_version:
-    name: Update Package Version from Tag
-    runs-on: ubuntu-latest
-    needs: [validate, update_version]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Extract version from tag and update package.json
-        id: extract_version
-        working-directory: ./gsd-opencode
-        run: |
-          echo "Extracting version from tag: ${{ github.ref_name }}"
-
-          # Extract version from git tag (remove 'v' prefix)
-          TAG_VERSION="${{ github.ref_name }}"
-          VERSION=${TAG_VERSION#v}
-          echo "Extracted version: $VERSION"
-
-          # Update package.json with the tag version
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-
-          # Verify the update
-          UPDATED_VERSION=$(node -p "require('./package.json').version")
-          echo "Updated package.json version to: $UPDATED_VERSION"
-
-          # Output for subsequent jobs
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          echo "✓ Package version updated to match tag"
-
-      - name: Update package name for npmjs.org
-        working-directory: ./gsd-opencode
-        run: |
-          echo "Updating package name for npmjs.org..."
-          npm pkg set name=gsd-opencode
-          UPDATED_NAME=$(node -p "require('./package.json').name")
-          echo "✓ Package name updated to: $UPDATED_NAME"
-
       - name: Upload updated package.json
         uses: actions/upload-artifact@v4
         with:
@@ -191,6 +151,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Full history for changelog generation
+
+      - name: Download updated package.json
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-package-json
+          path: ./gsd-opencode
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Remove duplicate update_version job causing workflow validation failure
- Clean up redundant job definition in release.yml
- Restore proper workflow structure for artifact sharing

## Additional important details

- 1 file changed, 6 insertions(+), 40 deletions(-)
- Changes in .github/workflows/release.yml