### PR TITLE
fix(ci): add checkout step to create_release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,9 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Add checkout step to create_release job for git access
- Fix "not a git repository" error when creating releases
- Ensure gh release create can access git context

## Additional important details

- 1 file changed, 3 insertions(+)
- Changes in .github/workflows/release.yml