### PR TITLE
fix(ci): check if release exists before creating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,13 +391,23 @@ jobs:
         run: |
           echo "Creating GitHub release for v${{ needs.update_version.outputs.version }}..."
 
-          # Create release
-          gh release create "v${{ needs.update_version.outputs.version }}" \
-            --title "gsd-opencode v${{ needs.update_version.outputs.version }}" \
-            --notes-file release-notes.md \
-            --latest
+          # Check if release already exists
+          if gh release view "v${{ needs.update_version.outputs.version }}" &>/dev/null; then
+            echo "Release v${{ needs.update_version.outputs.version }} already exists, updating..."
+            # Update existing release
+            gh release edit "v${{ needs.update_version.outputs.version }}" \
+              --title "gsd-opencode v${{ needs.update_version.outputs.version }}" \
+              --notes-file release-notes.md \
+              --latest
+          else
+            # Create new release
+            gh release create "v${{ needs.update_version.outputs.version }}" \
+              --title "gsd-opencode v${{ needs.update_version.outputs.version }}" \
+              --notes-file release-notes.md \
+              --latest
+          fi
 
-          echo "✓ GitHub release created"
+          echo "✓ GitHub release updated/created"
 
       - name: Upload release assets
         run: |


### PR DESCRIPTION
## Summary

- Add release existence check before creating new release
- Update existing release instead of failing when tag exists
- Fix "Release.tag_name already exists" error

## Additional important details

- 1 file changed, 16 insertions(+), 6 deletions(-)
- Changes in .github/workflows/release.yml