### PR TITLE
fix(ci): extract package.json from tarball and rename job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,8 +433,11 @@ jobs:
           # Find the tarball
           TARBALL=$(ls gsd-opencode-*.tgz)
 
-          # Extract package info
+          # Extract package.json from tarball to get package name
+          tar -xzf "$TARBALL" package/package.json --strip-components=1
           PACKAGE_NAME=$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).name")
+          rm package.json
+
           VERSION="${{ needs.update_version.outputs.version }}"
 
           echo "Publishing $TARBALL as $PACKAGE_NAME@$VERSION to npm using OIDC token"


### PR DESCRIPTION
## Summary

- Extract package.json from tarball to get package name
- Rename "Create GitHub Release" job to "Release to GH and NPM"
- Fix "ENOENT: no such file or directory" error when publishing to npm

## Additional important details

- 1 file changed, 5 insertions(+), 2 deletions(-)
- Changes in .github/workflows/release.yml