### PR TITLE
fix(ci): add setup-node for OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,12 @@ jobs:
 
           echo "✓ All release assets uploaded"
 
+      - name: Setup Node.js for OIDC
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Publish to npm
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
## Summary
- Added `actions/setup-node@v4` step to the `create_release` job
- Required for npm CLI to detect OIDC token from GitHub Actions environment
- Fixes `ENEEDAUTH` error during npm publish

## Issue
The release pipeline was failing with `ENEEDAUTH` error when publishing to npm using OIDC. The `npm publish` command was running without the `actions/setup-node` step, which is required for OIDC authentication.

## Solution
According to npmjs trusted publishers documentation, the `setup-node` action with `registry-url: 'https://registry.npmjs.org'` is required for npm CLI to detect the OIDC environment.

## Files Changed
- `.github/workflows/release.yml`: Added setup-node step before npm publish