### PR TITLE
debug: add OIDC detection debug step to diagnose auth issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,22 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Debug OIDC setup
+        run: |
+          echo "=== OIDC Debug Info ==="
+          echo "npm version: $(npm --version)"
+          echo "node version: $(node --version)"
+          echo ""
+          echo "=== Environment Variables ==="
+          env | grep -i oidc || echo "No OIDC env vars found"
+          env | grep -i token || echo "No TOKEN env vars found"
+          echo ""
+          echo "=== npm config ==="
+          npm config list
+          echo ""
+          echo "=== npm whoami ==="
+          npm whoami || echo "npm whoami failed - this is expected if OIDC not working"
+
       - name: Publish to npm
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
## Summary
- Added debug step to verify OIDC setup before npm publish
- Checks npm/node versions, environment variables, npm config, and authentication status
- Will help diagnose why npm CLI isn't detecting OIDC environment

## Context
Release pipeline continues failing with `ENEEDAUTH` error despite having `id-token: write` permission and setup-node configured. This debug step will reveal:
- If OIDC environment variables are present
- npm CLI version (needs 11.5.1+ for OIDC)
- What authentication method npm is attempting
- npm configuration state

## Files Changed
- `.github/workflows/release.yml`: Added debug step before npm publish