### PR TITLE
fix: upgrade npm to 11.5.1+ for OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,9 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Upgrade npm to 11.5.1+ for OIDC support
+        run: npm install -g npm@latest
+
       - name: Debug OIDC setup
         run: |
           echo "=== OIDC Debug Info ==="


### PR DESCRIPTION
## Summary
- Added npm upgrade step to install latest npm (11.5.1+)
- npm 10.8.2 (bundled with Node 18) doesn't support OIDC
- npmjs requires npm CLI version 11.5.1 or later for trusted publishing

## Issue
Debug output revealed:
- npm version: 10.8.2 (too old)
- No OIDC environment variables detected by npm

According to npmjs trusted publishing documentation: "Trusted publishing requires npm CLI version 11.5.1 or later."

## Solution
Install latest npm version after setting up Node.js. This enables OIDC support so npm CLI can detect GitHub Actions OIDC environment.

## Files Changed
- `.github/workflows/release.yml`: Added npm upgrade step