### PR TITLE
fix: upgrade Node.js to 20 for npm 11.5.1+ OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,10 +426,7 @@ jobs:
       - name: Setup Node.js for OIDC
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
-
-      - name: Upgrade npm to 11.5.1+ for OIDC support
-        run: npm install -g npm@latest
+          node-version: "20"
 
       - name: Debug OIDC setup
         run: |


### PR DESCRIPTION
## Summary
- Changed Node.js version from 18 to 20 in `create_release` job
- Node.js 20 includes npm 11.5.1+ which supports OIDC
- Removed manual npm upgrade step since Node 20 has compatible npm version

## Issue
npm 11.7.0 requires Node.js ^20.17.0 || >=22.9.0, but we were using Node 18.
Previous attempt to manually upgrade npm failed with:
```
npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
```

## Solution
Use Node.js 20 instead of 18 in the `create_release` job. Node.js 20 comes bundled with npm 10.9.0+, which supports OIDC authentication for npm publishing.

## Files Changed
- `.github/workflows/release.yml`: Changed node-version from 18 to 20, removed manual npm upgrade step