### PR TITLE
fix: upgrade npm to 11.7.0 with Node 20 for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,9 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Upgrade npm to 11.7.0 for OIDC support
+        run: npm install -g npm@11.7.0
+
       - name: Debug OIDC setup
         run: |
           echo "=== OIDC Debug Info ==="


### PR DESCRIPTION
## Summary
- Added npm upgrade step to install npm@11.7.0 after Node 20 setup
- Node 20.19.6 meets the >=20.17.0 requirement for npm 11.7.0
- npm 11.7.0 supports OIDC authentication

## Issue
Node 20.19.6 still comes with npm 10.8.2, which doesn't support OIDC.
Debug output showed:
- node version: v20.19.6 ✓
- npm version: 10.8.2 ✗ (needs 11.5.1+)
- OIDC env vars present but npm can't detect them

npm 11.7.0 requires Node.js ^20.17.0 || >=22.9.0, which we now have.

## Solution
Manually upgrade npm to 11.7.0 after setting up Node.js 20. This enables OIDC support so npm CLI can detect and use GitHub Actions OIDC environment.

## Files Changed
- `.github/workflows/release.yml`: Added npm upgrade step with version 11.7.0