### PR TITLE
fix: correct GitHub repository URLs to gsd-opencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-01-19
+
+Fixed repository URLs to point to gsd-opencode repository.
+
+### Changed
+- Updated GitHub repository URLs from rokicool/get-shit-done to rokicool/gsd-opencode in command/gsd/update.md and command/gsd/whats-new.md
+
 ## [1.6.0] - 2026-01-19
 
 Catch up with original [Get-Shit-Done v1.6.4](https://github.com/glittercowboy/get-shit-done/blob/main/CHANGELOG.md#164---2026-01-17).

--- a/assets/antipatterns.toml
+++ b/assets/antipatterns.toml
@@ -21,5 +21,6 @@ forbidden_strings = [
         "TodoWrite",
         "WebSearch",
         "WebFetch",
-        "BashOutput"
+        "BashOutput",
+        "rokicool/get-shit-done"
         ]

--- a/gsd-opencode/command/gsd/update.md
+++ b/gsd-opencode/command/gsd/update.md
@@ -154,7 +154,7 @@ Format completion message (changelog was already shown in confirmation step):
 
 ⚠️  Restart OpenCode to pick up the new commands.
 
-[View full changelog](https://github.com/rokicool/get-shit-done/blob/main/CHANGELOG.md)
+[View full changelog](https://github.com/rokicool/gsd-opencode/blob/main/CHANGELOG.md)
 ```
 </step>
 

--- a/gsd-opencode/command/gsd/whats-new.md
+++ b/gsd-opencode/command/gsd/whats-new.md
@@ -38,7 +38,7 @@ STOP here if no VERSION file.
 Fetch latest CHANGELOG.md from GitHub:
 
 Use webfetch tool with:
-- URL: `https://raw.githubusercontent.com/rokicool/get-shit-done/main/CHANGELOG.md`
+- URL: `https://raw.githubusercontent.com/rokicool/gsd-opencode/main/CHANGELOG.md`
 - Prompt: "Extract all version entries with their dates and changes. Return in Keep-a-Changelog format."
 
 **If fetch fails:**
@@ -75,7 +75,7 @@ Format output clearly:
 
 You're on the latest version.
 
-[View full changelog](https://github.com/rokicool/get-shit-done/blob/main/CHANGELOG.md)
+[View full changelog](https://github.com/rokicool/gsd-opencode/blob/main/CHANGELOG.md)
 ```
 
 **If updates available:**
@@ -105,7 +105,7 @@ You're on the latest version.
 
 ---
 
-[View full changelog](https://github.com/rokicool/get-shit-done/blob/main/CHANGELOG.md)
+[View full changelog](https://github.com/rokicool/gsd-opencode/blob/main/CHANGELOG.md)
 
 **To update:** `npx gsd-opencode --global`
 ```


### PR DESCRIPTION
### Summary
- Fixed repository URLs in gsd-update and gsd-whats-new commands
- Added forbidden string pattern to prevent incorrect URLs in future
- Updated CHANGELOG with v1.6.1 entry documenting the fix
### Additional important details
- 4 files changed, 13 insertions, 5 deletions
- Corrects URLs from rokicool/get-shit-done to rokicool/gsd-opencode in update.md (1 URL) and whats-new.md (3 URLs)
- Added "rokicool/get-shit-done" to forbidden_strings in assets/antipatterns.toml