### PR TITLE
fix: remove backticks from new-project command examples

### DIFF
--- a/gsd-opencode/command/gsd/new-project.md
+++ b/gsd-opencode/command/gsd/new-project.md
@@ -1014,14 +1014,14 @@ Present completion with next steps:
 
 **Phase 1: [Phase Name]** — [Goal from ROADMAP.md]
 
-`/gsd-discuss-phase 1` — gather context and clarify approach
+/gsd-discuss-phase 1 — gather context and clarify approach
 
-*`/new` first → fresh context window*
+*/new first → fresh context window*
 
 ---
 
 **Also available:**
-- `/gsd-plan-phase 1` — skip discussion, plan directly
+- /gsd-plan-phase 1 — skip discussion, plan directly
 
 ───────────────────────────────────────────────────────────────
 ```


### PR DESCRIPTION
## Summary
- Remove backtick formatting from `/gsd-discuss-phase 1` command example
- Remove backtick formatting from `/new` context window note
- Remove backtick formatting from `/gsd-plan-phase 1` command example
- Standardize command formatting in new-project.md documentation
## Additional important details
- **Files changed:** 1 file (gsd-opencode/command/gsd/new-project.md)
- **Lines changed:** +3 insertions, -3 deletions
- **Type:** fix (documentation formatting consistency)
- **Impact:** Low - cosmetic formatting fix for command examples