### PR TITLE
Update subagent type from task to general in workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-02-27
+
+Overview: Updated subagent type references from "task" to "general" across workflow files for compatibility with the current agent system. Added path replacement rule for future installations.
+
+### Changed
+
+- Updated `subagent_type="task"` to `subagent_type="general"` in `gsd-opencode/commands/gsd/gsd-research-phase.md`, `gsd-opencode/get-shit-done/workflows/diagnose-issues.md`, `gsd-opencode/get-shit-done/workflows/discuss-phase.md`, `gsd-opencode/get-shit-done/workflows/new-project.md`, `gsd-opencode/get-shit-done/workflows/plan-phase.md`, and `gsd-opencode/get-shit-done/workflows/quick.md`
+- Added path replacement rule in `assets/configs/config.json` to transform `subagent_type="task"` to `subagent_type="general"` during installation
+
 ## [1.20.1] - 2026-02-27
 
 Overview: Renamed project instructions file from OPENCODE.md to AGENTS.md for broader AI agent compatibility. Updated path replacement rules and gitignore patterns.

--- a/assets/configs/config.json
+++ b/assets/configs/config.json
@@ -600,6 +600,12 @@
       "description": "Transform Explore subagent type to lowercase explore"
     },
     {
+      "pattern": "subagent_type=\"task\"",
+      "replacement": "subagent_type=\"general\"",
+      "caseSensitive": true,
+      "description": "Transform task subagent type to general"
+    },
+    {
       "pattern": "CLAUDE.md",
       "replacement": "AGENTS.md",
       "caseSensitive": true,

--- a/gsd-opencode/commands/gsd/gsd-research-phase.md
+++ b/gsd-opencode/commands/gsd/gsd-research-phase.md
@@ -136,7 +136,7 @@ write to: .planning/phases/${PHASE}-{slug}/${PHASE}-RESEARCH.md
 ```
 task(
   prompt="First, read ~/.config/opencode/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + filled_prompt,
-  subagent_type="task",
+  subagent_type="general",
   model="{researcher_model}",
   description="Research Phase {phase}"
 )
@@ -172,7 +172,7 @@ Continue research for Phase {phase_number}: {phase_name}
 ```
 task(
   prompt="First, read ~/.config/opencode/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + continuation_prompt,
-  subagent_type="task",
+  subagent_type="general",
   model="{researcher_model}",
   description="Continue research Phase {phase}"
 )

--- a/gsd-opencode/get-shit-done/workflows/diagnose-issues.md
+++ b/gsd-opencode/get-shit-done/workflows/diagnose-issues.md
@@ -80,7 +80,7 @@ For each gap, fill the debug-subagent-prompt template and spawn:
 ```
 task(
   prompt=filled_debug_subagent_prompt + "\n\n<files_to_read>\n- {phase_dir}/{phase_num}-UAT.md\n- .planning/STATE.md\n</files_to_read>",
-  subagent_type="task",
+  subagent_type="general",
   description="Debug: {truth_short}"
 )
 ```

--- a/gsd-opencode/get-shit-done/workflows/discuss-phase.md
+++ b/gsd-opencode/get-shit-done/workflows/discuss-phase.md
@@ -488,7 +488,7 @@ task(
     6. Return: PHASE COMPLETE (full pipeline success), PLANNING COMPLETE (planning done but execute failed/skipped), PLANNING INCONCLUSIVE, or GAPS FOUND
     </instructions>
   ",
-  subagent_type="task",
+  subagent_type="general",
   description="Plan Phase ${PHASE}"
 )
 ```

--- a/gsd-opencode/get-shit-done/workflows/new-project.md
+++ b/gsd-opencode/get-shit-done/workflows/new-project.md
@@ -582,7 +582,7 @@ Your STACK.md feeds into roadmap creation. Be prescriptive:
 write to: .planning/research/STACK.md
 Use template: ~/.config/opencode/get-shit-done/templates/research-project/STACK.md
 </output>
-", subagent_type="task", model="{researcher_model}", description="Stack research")
+", subagent_type="general", model="{researcher_model}", description="Stack research")
 
 task(prompt="First, read ~/.config/opencode/agents/gsd-project-researcher.md for your role and instructions.
 
@@ -622,7 +622,7 @@ Your FEATURES.md feeds into requirements definition. Categorize clearly:
 write to: .planning/research/FEATURES.md
 Use template: ~/.config/opencode/get-shit-done/templates/research-project/FEATURES.md
 </output>
-", subagent_type="task", model="{researcher_model}", description="Features research")
+", subagent_type="general", model="{researcher_model}", description="Features research")
 
 task(prompt="First, read ~/.config/opencode/agents/gsd-project-researcher.md for your role and instructions.
 
@@ -662,7 +662,7 @@ Your ARCHITECTURE.md informs phase structure in roadmap. Include:
 write to: .planning/research/ARCHITECTURE.md
 Use template: ~/.config/opencode/get-shit-done/templates/research-project/ARCHITECTURE.md
 </output>
-", subagent_type="task", model="{researcher_model}", description="Architecture research")
+", subagent_type="general", model="{researcher_model}", description="Architecture research")
 
 task(prompt="First, read ~/.config/opencode/agents/gsd-project-researcher.md for your role and instructions.
 
@@ -702,7 +702,7 @@ Your PITFALLS.md prevents mistakes in roadmap/planning. For each pitfall:
 write to: .planning/research/PITFALLS.md
 Use template: ~/.config/opencode/get-shit-done/templates/research-project/PITFALLS.md
 </output>
-", subagent_type="task", model="{researcher_model}", description="Pitfalls research")
+", subagent_type="general", model="{researcher_model}", description="Pitfalls research")
 ```
 
 After all 4 agents complete, spawn synthesizer to create SUMMARY.md:

--- a/gsd-opencode/get-shit-done/workflows/plan-phase.md
+++ b/gsd-opencode/get-shit-done/workflows/plan-phase.md
@@ -117,7 +117,7 @@ write to: {phase_dir}/{phase_num}-RESEARCH.md
 ```
 task(
   prompt="First, read ~/.config/opencode/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + research_prompt,
-  subagent_type="task",
+  subagent_type="general",
   model="{researcher_model}",
   description="Research Phase {phase}"
 )
@@ -230,7 +230,7 @@ Output consumed by /gsd-execute-phase. Plans need:
 ```
 task(
   prompt="First, read ~/.config/opencode/agents/gsd-planner.md for your role and instructions.\n\n" + filled_prompt,
-  subagent_type="task",
+  subagent_type="general",
   model="{planner_model}",
   description="Plan Phase {phase}"
 )
@@ -327,7 +327,7 @@ Return what changed.
 ```
 task(
   prompt="First, read ~/.config/opencode/agents/gsd-planner.md for your role and instructions.\n\n" + revision_prompt,
-  subagent_type="task",
+  subagent_type="general",
   model="{planner_model}",
   description="Revise Phase {phase} plans"
 )
@@ -396,7 +396,7 @@ task(
     7. Do NOT use the skill tool or /gsd- commands
     </instructions>
   ",
-  subagent_type="task",
+  subagent_type="general",
   description="Execute Phase ${PHASE}"
 )
 ```

--- a/gsd-opencode/get-shit-done/workflows/quick.md
+++ b/gsd-opencode/get-shit-done/workflows/quick.md
@@ -223,7 +223,7 @@ Return what changed.
 ```
 task(
   prompt="First, read ~/.config/opencode/agents/gsd-planner.md for your role and instructions.\n\n" + revision_prompt,
-  subagent_type="task",
+  subagent_type="general",
   model="{planner_model}",
   description="Revise quick plan: ${DESCRIPTION}"
 )


### PR DESCRIPTION
- Changed subagent_type="task" to subagent_type="general" across workflow files
- Added path replacement rule in config.json for installation
- Updated CHANGELOG.md with v1.20.2 release notes