### PR TITLE
Fix YAML frontmatter errors and update translation config (v1.33.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.3] - 2026-04-12
+
+Overview: Fixed YAML frontmatter parse errors across 11 command files by quoting unquoted argument-hint values, corrected malformed skill permission in gsd-manager, and updated translation config with new rules for skill permissions and argument-hint quoting.
+
+### Fixed
+
+- Quoted unquoted `argument-hint` YAML values in 11 command files (`gsd-add-backlog`, `gsd-add-phase`, `gsd-add-todo`, `gsd-check-todos`, `gsd-complete-milestone`, `gsd-debug`, `gsd-health`, `gsd-insert-phase`, `gsd-remove-phase`, `gsd-set-profile`, `gsd-thread`) to prevent YAML parse errors with bracketed values like `[--flag]`
+- Corrected malformed `  - skill` permission entry to `skill: true` in `gsd-opencode/commands/gsd/gsd-manager.md`
+
+### Changed
+
+- Added `skill` to the YAML list-item permission translation regex in `assets/configs/config.json`
+- Added `argument-hint` auto-quoting translation rule in `assets/configs/config.json` to wrap unquoted values in double quotes during sync
+
 ## [1.33.1] - 2026-04-07
 
 Overview: Added M-TRANSLATE.md workflow for sync from upstream GSD, updated gsd-set-profile to remove model constraint, converted task() calls to @subagent syntax, and enhanced discovery and discuss-phase workflows.

--- a/assets/configs/config.json
+++ b/assets/configs/config.json
@@ -229,7 +229,7 @@
     },
     {
       "_comment": "regex for tools",
-      "pattern": "^([\\s]*)- (read|write|edit|bash|glob|grep|question|task|webfetch|todowrite)$",
+      "pattern": "^([\\s]*)- (read|write|edit|bash|glob|grep|question|task|webfetch|todowrite|skill)$",
       "replacement": "$1 $2: true",
       "caseSensitive": true,
       "isRegex": true,
@@ -528,6 +528,14 @@
       "pattern": "\"quality\" | \"balanced\" | \"budget\"",
       "replacement": "\"simple\" | \"smart\" | \"genius\"",
       "description": "Use - three models - profile"
+    },
+    {
+      "_comment": "Quote unquoted argument-hint values to prevent YAML parse errors (e.g. [--flag] is parsed as array)",
+      "pattern": "^(argument-hint: )([^\"].*)",
+      "replacement": "$1\"$2\"",
+      "caseSensitive": true,
+      "isRegex": true,
+      "description": "Wrap unquoted argument-hint YAML values in double quotes"
     }
   ],
   "_forbidden_strings_after_translation": [

--- a/gsd-opencode/commands/gsd/gsd-add-backlog.md
+++ b/gsd-opencode/commands/gsd/gsd-add-backlog.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-add-backlog
 description: Add an idea to the backlog parking lot (999.x numbering)
-argument-hint: <description>
+argument-hint: "<description>"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-add-phase.md
+++ b/gsd-opencode/commands/gsd/gsd-add-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-add-phase
 description: Add phase to end of current milestone in roadmap
-argument-hint: <description>
+argument-hint: "<description>"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-add-todo.md
+++ b/gsd-opencode/commands/gsd/gsd-add-todo.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-add-todo
 description: Capture idea or task as todo from current conversation context
-argument-hint: [optional description]
+argument-hint: "[optional description]"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-check-todos.md
+++ b/gsd-opencode/commands/gsd/gsd-check-todos.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-check-todos
 description: List pending todos and select one to work on
-argument-hint: [area filter]
+argument-hint: "[area filter]"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-complete-milestone.md
+++ b/gsd-opencode/commands/gsd/gsd-complete-milestone.md
@@ -2,7 +2,7 @@
 type: prompt
 name: gsd-complete-milestone
 description: Archive completed milestone and prepare for next version
-argument-hint: <version>
+argument-hint: "<version>"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-debug.md
+++ b/gsd-opencode/commands/gsd/gsd-debug.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-debug
 description: Systematic debugging with persistent state across context resets
-argument-hint: [--diagnose] [issue description]
+argument-hint: "[--diagnose] [issue description]"
 permissions:
    read: true
    bash: true

--- a/gsd-opencode/commands/gsd/gsd-health.md
+++ b/gsd-opencode/commands/gsd/gsd-health.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-health
 description: Diagnose planning directory health and optionally repair issues
-argument-hint: [--repair]
+argument-hint: "[--repair]"
 permissions:
    read: true
    bash: true

--- a/gsd-opencode/commands/gsd/gsd-insert-phase.md
+++ b/gsd-opencode/commands/gsd/gsd-insert-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-insert-phase
 description: Insert urgent work as decimal phase (e.g., 72.1) between existing phases
-argument-hint: <after> <description>
+argument-hint: "<after> <description>"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-manager.md
+++ b/gsd-opencode/commands/gsd/gsd-manager.md
@@ -8,7 +8,7 @@ permissions:
    glob: true
    grep: true
    question: true
-  - skill
+   skill: true
    task: true
 ---
 <objective>

--- a/gsd-opencode/commands/gsd/gsd-remove-phase.md
+++ b/gsd-opencode/commands/gsd/gsd-remove-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-remove-phase
 description: Remove a future phase from roadmap and renumber subsequent phases
-argument-hint: <phase-number>
+argument-hint: "<phase-number>"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/commands/gsd/gsd-set-profile.md
+++ b/gsd-opencode/commands/gsd/gsd-set-profile.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-set-profile
 description: Switch model profile for GSD agents (simple/smart/genius/inherit)
-argument-hint: <profile (simple|smart|genius|inherit)>
+argument-hint: "<profile (simple|smart|genius|inherit)>"
 permissions:
    bash: true
 ---

--- a/gsd-opencode/commands/gsd/gsd-thread.md
+++ b/gsd-opencode/commands/gsd/gsd-thread.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-thread
 description: Manage persistent context threads for cross-session work
-argument-hint: [name | description]
+argument-hint: "[name | description]"
 permissions:
    read: true
    write: true

--- a/gsd-opencode/get-shit-done/workflows/discovery-phase.md
+++ b/gsd-opencode/get-shit-done/workflows/discovery-phase.md
@@ -93,7 +93,7 @@ For: Choosing between options, new external integration.
 
    ```
    For each library/framework:
-   - mcp__context7__resolve-library-id   
+   - mcp__context7__resolve-library-id     
    - mcp__context7__get-library-docs (mode: "code" for API, "info" for concepts)
    ```
 


### PR DESCRIPTION
## Summary

- Quote unquoted `argument-hint` YAML values in 11 command files to prevent YAML parse errors with bracketed values like `[--flag]`
- Fix malformed `  - skill` permission entry to `skill: true` in `gsd-manager.md`
- Update translation config (`config.json`) with `skill` in the permission regex and a new `argument-hint` auto-quoting rule
- Add CHANGELOG entry for v1.33.3

## Changes

### Fixed
- 11 command frontmatter files (`gsd-add-backlog`, `gsd-add-phase`, `gsd-add-todo`, `gsd-check-todos`, `gsd-complete-milestone`, `gsd-debug`, `gsd-health`, `gsd-insert-phase`, `gsd-remove-phase`, `gsd-set-profile`, `gsd-thread`) had unquoted `argument-hint` values that caused YAML parse errors when values contained brackets
- `gsd-manager.md` had a malformed `- skill` line instead of `skill: true` in the permissions block

### Changed
- `assets/configs/config.json` — added `skill` to the YAML list-item permission translation regex
- `assets/configs/config.json` — added argument-hint auto-quoting translation rule to wrap unquoted values in double quotes during sync

## Test plan

- [x] `gsd-translate-in-place.js --show-diff` preview confirms correct translations
- [x] `check-forbidden-strings.js` passes with 0 violations across 302 files
- [x] Re-run of `gsd-translate-in-place.js` confirms 0 remaining changes (idempotent)