### PR TITLE
v1.38.5: Fix gsd-oc-set-profile frontmatter name and add CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.5] - 2026-04-28
+
+Overview: Fixed frontmatter command name in gsd-oc-set-profile from incorrect gsd-set-profile to the correct OpenCode-prefixed name.
+
+### Fixed
+
+- Corrected frontmatter `name` field from `gsd-set-profile` to `gsd-oc-set-profile` in `gsd-opencode/commands/gsd/gsd-oc-set-profile.md`
+
 ## [1.38.3] - 2026-04-27
 
 Overview: Synced upstream GSD to v1.38.5 and translated all Claude Code artifacts to OpenCode equivalents across 200+ files. Added `gsd-edit-phase` command and `edit-phase` workflow for modifying existing roadmap phases in place. Introduced post-merge gate to execute-phase workflow. Fixed SDK runtime detection defaults to use `claude` instead of `OpenCode` throughout the query layer. Added missing `<objective>` sections to command files to satisfy CI validation.

--- a/gsd-opencode/commands/gsd/gsd-oc-set-profile.md
+++ b/gsd-opencode/commands/gsd/gsd-oc-set-profile.md
@@ -1,12 +1,10 @@
 ---
-name: gsd-set-profile
+name: gsd-oc-set-profile
 description: Switch model profile for GSD agents (simple/smart/genius/inherit)
 argument-hint: "<profile (simple|smart|genius|inherit)>"
 permissions:
-   bash: true
+  bash: true
 ---
-
-
 
 <objective>
       Switch the model profile used by GSD agents. Controls which OpenCode model each agent uses, balancing quality vs token spend.
@@ -31,4 +29,4 @@ permissions:
       3. Config reading and updating
       4. Model table generation from MODEL_PROFILES
       5. Confirmation display
-      </process> 
+      </process>


### PR DESCRIPTION
## Summary

- Fixed frontmatter `name` field from `gsd-set-profile` to `gsd-oc-set-profile` in the set-profile command file
- Added CHANGELOG entry for v1.38.5 documenting the fix